### PR TITLE
Inclusion de Milton Mazzarri en instancia MX

### DIFF
--- a/authors/m/mi/milton_mazzarri.yml
+++ b/authors/m/mi/milton_mazzarri.yml
@@ -1,7 +1,8 @@
 --- 
 countries: 
   - ve
-email: ~
+  - mx
+email: milmazz@gmail.com
 enabled: 'on'
 face: ve/milton.png
 filename: milton_mazzarri


### PR DESCRIPTION
Se incluye a Milton Mazzarri en la instancia mexicana de Planeta Linux, se agrega datos del correo electronico
