### PR TITLE
Update oliver_rivas.yaml

### DIFF
--- a/authors/o/ol/oliver_rivas.yaml
+++ b/authors/o/ol/oliver_rivas.yaml
@@ -8,4 +8,4 @@ filename: oliver_rivas
 message: ~
 name: Oliver Rivas
 twitter: orvtech
-url: http://orvtech.com/category/general/feed/
+url: http://orvtech.com/tag/linux/feed/


### PR DESCRIPTION
Cambié el feed del blog por el feed del tag linux. Esto debería de permitirme controlar de forma mas granulada que aparece en planetalinux y que no
