### PR TITLE
Update rss feed for jos_luis_rivas.yml

### DIFF
--- a/authors/j/jo/jos_luis_rivas.yml
+++ b/authors/j/jo/jos_luis_rivas.yml
@@ -8,4 +8,4 @@ filename: jos_luis_rivas
 message: ~
 name: "Jos\xC3\xA9 Luis Rivas"
 twitter: ghostbar
-url: http://ghostbar.ath.cx/feed-planetalinux.xml
+url: http://ghostbar.co/feed-planetalinux.xml


### PR DESCRIPTION
Now is ghostbar.co instead of ghostbar.ath.cx
