### PR TITLE
cambiando feed de tuxsoul sin ssl ...

### DIFF
--- a/authors/m/ma/mario_oyorz_225_bal.yml
+++ b/authors/m/ma/mario_oyorz_225_bal.yml
@@ -8,4 +8,4 @@ filename: mario_oyorz_225_bal
 message: ~
 name: Mario Oyorz&#225;bal
 twitter: tuxsoul
-url: https://blog.tuxsoul.com/etiqueta/software-libre/feed/
+url: http://blog.tuxsoul.com/etiqueta/software-libre/feed/


### PR DESCRIPTION
Que tal,

Jugando un poco con el codigo de planetalinux, para levantar el planetalinuxmorelos, veo que hay un detalle cuando el feed, se encuentra en ssl, dando un error:

`ERROR:planet.runner:HttpLib2Error: [Errno 1] _ssl.c:510: error:14077438:SSL routines:SSL23_GET_SERVER_HELLO:tlsv1 alert internal error via 0 `                                                 

Al estar leyendo varios dias sobre esto lo mas sano que veo es sacar mi feed del ssl, esto es un detalle de la version de python2 y openssl, aunque se cambie el codigo de httplib2 en venus por ssl.PROTOCOL_TLSv1, el problema ahora es el cifrado del certificado.

Es posible que otros feeds, se vean afectados, por lo que pongo el comentario anterior por si le sirve a alguien.

Mil disculpas  por la molestia, saludos :wink: ...

Signed-off-by: Mario Oyorzabal Salgado <tuxsoul@gmail.com>